### PR TITLE
Decouple AircraftStore from the system time

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ The `message` must be a decoded Mode S message received in `detect`
 callback from the
 [mode-s-decoder](https://github.com/watson/mode-s-decoder) module.
 
-You can provide the original `receptionTime` as a `Date` object if it's different from the current system time.
+You can provide the original `receptionTime` as a Unix timestamp (in milliseconds) if it's different from the current system time.
 
 ### `aircrafts = store.getAircrafts([currentTime])`
 
 Return an array of aircrafts currently in the `store`.
 
-If you're not using the store for messages received in real time you can override the current time by passing an optional `Date` object as the first argument.
+If you're not using the store for messages received in real time you can override the current time by passing an optional Unix timestamp (in milliseconds) as the first argument.
 
 Each aircraft have the following properties:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The following options are available:
   from the store if no message from it have been seen (default:
   `120000`)
 
-### `store.addMessage(message)`
+### `store.addMessage(message, [receptionTime])`
 
 Add a new `message` to the `store`.
 
@@ -68,9 +68,13 @@ The `message` must be a decoded Mode S message received in `detect`
 callback from the
 [mode-s-decoder](https://github.com/watson/mode-s-decoder) module.
 
-### `aircrafts = store.getAircrafts()`
+You can provide the original `receptionTime` as a `Date` object if it's different from the current system time.
+
+### `aircrafts = store.getAircrafts([currentTime])`
 
 Return an array of aircrafts currently in the `store`.
+
+If you're not using the store for messages received in real time you can override the current time by passing an optional `Date` object as the first argument.
 
 Each aircraft have the following properties:
 

--- a/index.js
+++ b/index.js
@@ -12,22 +12,24 @@ function AircraftStore (opts) {
   this._index = {}
 }
 
-AircraftStore.prototype.addMessage = function (msg) {
+AircraftStore.prototype.addMessage = function (msg, receptionTime) {
+  receptionTime = receptionTime || Date.now()
   const aircraft = this._index[msg.icao] = this._index[msg.icao] || new Aircraft()
-  aircraft.update(msg)
+  aircraft.update(msg, receptionTime)
 }
 
-AircraftStore.prototype.getAircrafts = function () {
+AircraftStore.prototype.getAircrafts = function (currentTime) {
+  currentTime = currentTime || Date.now()
   const self = this
-  this._prune()
+  this._prune(currentTime)
   return Object.keys(this._index).map(function (icao) {
     return self._index[icao]
   })
 }
 
-AircraftStore.prototype._prune = function () {
+AircraftStore.prototype._prune = function (currentTime) {
   const self = this
-  const threshold = Date.now() - this._timeout
+  const threshold = currentTime - this._timeout
   Object.keys(this._index).forEach(function (icao) {
     const aircraft = self._index[icao]
     if (aircraft.seen < threshold) {

--- a/lib/aircraft.js
+++ b/lib/aircraft.js
@@ -26,9 +26,9 @@ function Aircraft () {
   this._evenCprTime = 0
 }
 
-Aircraft.prototype.update = function (msg) {
+Aircraft.prototype.update = function (msg, receptionTime) {
   this.count++
-  this.seen = Date.now()
+  this.seen = receptionTime
   this.icao = msg.icao
 
   if (msg.msgtype === 0 || msg.msgtype === 4 || msg.msgtype === 20) {
@@ -43,11 +43,11 @@ Aircraft.prototype.update = function (msg) {
       if (msg.fflag) {
         this._oddCprLat = msg.rawLatitude
         this._oddCprLng = msg.rawLongitude
-        this._oddCprTime = Date.now()
+        this._oddCprTime = receptionTime
       } else {
         this._evenCprLat = msg.rawLatitude
         this._evenCprLng = msg.rawLongitude
-        this._evenCprTime = Date.now()
+        this._evenCprTime = receptionTime
       }
 
       // if the two messages are less than 10 seconds apart, compute the position

--- a/test.js
+++ b/test.js
@@ -73,7 +73,7 @@ test('cpr timeout with system time', function (t) {
   const start = Date.now()
 
   // if more than 10 seconds between messages, lat/lng decoding will be
-  // skipped, so lets simulate a long wait between messages
+  // skipped, so lets simulate a long delay between messages
   const options = {
     refTime: null,
     timeBetweenMessages: 11000
@@ -162,13 +162,24 @@ test('store timeout with reference time', function (t) {
 
 function populateStore (store, options, cb) {
   options.decoder = options.decoder || new Decoder()
-  options.refTime = options.refTime || Date.now()
 
-  for (let i = 0; i < msgs.length; i++) {
-    store.addMessage(
-      options.decoder.parse(msgs[i]),
-      options.refTime + options.timeBetweenMessages * i
-    )
+  if (options.refTime) {
+    for (let i = 0; i < msgs.length; i++) {
+      store.addMessage(
+        options.decoder.parse(msgs[i]),
+        options.refTime + options.timeBetweenMessages * i
+      )
+    }
+  } else {
+    const start = Date.now()
+    const origNow = Date.now
+
+    for (let i = 0; i < msgs.length; i++) {
+      Date.now = () => start + options.timeBetweenMessages * i
+      store.addMessage(options.decoder.parse(msgs[i]))
+    }
+
+    Date.now = origNow
   }
 
   return cb()

--- a/test.js
+++ b/test.js
@@ -11,11 +11,16 @@ const msgs = [
   Buffer.from('8d780d9f58a10124566d9184e589', 'hex')
 ]
 
-test('normal', function (t) {
+test('normal with system time', function (t) {
   const store = new AircraftStore()
   const start = Date.now()
 
-  populateStore(store, function () {
+  const options = {
+    refTime: null,
+    timeBetweenMessages: 1
+  }
+
+  populateStore(store, options, function () {
     const aircrafts = store.getAircrafts()
     t.equal(aircrafts.length, 1)
 
@@ -23,7 +28,6 @@ test('normal', function (t) {
     t.equal(aircraft.icao, 7867807)
     t.equal(aircraft.count, msgs.length)
     t.ok(aircraft.seen >= start)
-    t.ok(aircraft.seen <= Date.now())
     t.equal(aircraft.altitude, 31000)
     t.equal(aircraft.unit, 0)
     t.equal(aircraft.speed, 506.66359648192605)
@@ -36,19 +40,46 @@ test('normal', function (t) {
   })
 })
 
-test('cpr timeout', function (t) {
+test('normal with reference time', function (t) {
+  const store = new AircraftStore()
+
+  const options = {
+    refTime: 4815162342,
+    timeBetweenMessages: 1
+  }
+
+  populateStore(store, options, function () {
+    const aircrafts = store.getAircrafts(options.refTime)
+    t.equal(aircrafts.length, 1)
+
+    const aircraft = aircrafts[0]
+    t.equal(aircraft.icao, 7867807)
+    t.equal(aircraft.count, msgs.length)
+    t.ok(aircraft.seen >= options.refTime)
+    t.equal(aircraft.altitude, 31000)
+    t.equal(aircraft.unit, 0)
+    t.equal(aircraft.speed, 506.66359648192605)
+    t.equal(aircraft.heading, 65.76194226683805)
+    t.equal(aircraft.lat, 55.71290588378906)
+    t.equal(aircraft.lng, 13.243602405894885)
+    t.equal(aircraft.callsign, '')
+
+    t.end()
+  })
+})
+
+test('cpr timeout with system time', function (t) {
   const store = new AircraftStore()
   const start = Date.now()
 
   // if more than 10 seconds between messages, lat/lng decoding will be
-  // skipped, so lets hack the clock to simulate that scenario
-  let offset = 0
-  const origNow = Date.now
-  Date.now = function () {
-    return start + offset++ * 10001
+  // skipped, so lets simulate a long wait between messages
+  const options = {
+    refTime: null,
+    timeBetweenMessages: 11000
   }
 
-  populateStore(store, function () {
+  populateStore(store, options, function () {
     const aircrafts = store.getAircrafts()
     t.equal(aircrafts.length, 1)
 
@@ -56,7 +87,6 @@ test('cpr timeout', function (t) {
     t.equal(aircraft.icao, 7867807)
     t.equal(aircraft.count, msgs.length)
     t.ok(aircraft.seen >= start)
-    t.ok(aircraft.seen <= Date.now())
     t.equal(aircraft.altitude, 31000)
     t.equal(aircraft.unit, 0)
     t.equal(aircraft.speed, 506.66359648192605)
@@ -66,31 +96,80 @@ test('cpr timeout', function (t) {
     t.equal(aircraft.callsign, '')
 
     t.end()
-
-    Date.now = origNow
   })
 })
 
-test('store timeout', function (t) {
+test('cpr timeout with reference time', function (t) {
+  const store = new AircraftStore()
+
+  // if more than 10 seconds between messages, lat/lng decoding will be
+  // skipped, so lets simulate a long delay between messages
+  const options = {
+    refTime: 4815162342,
+    timeBetweenMessages: 11000
+  }
+
+  populateStore(store, options, function () {
+    const aircrafts = store.getAircrafts(options.refTime)
+    t.equal(aircrafts.length, 1)
+
+    const aircraft = aircrafts[0]
+    t.equal(aircraft.icao, 7867807)
+    t.equal(aircraft.count, msgs.length)
+    t.ok(aircraft.seen >= options.refTime)
+    t.equal(aircraft.altitude, 31000)
+    t.equal(aircraft.unit, 0)
+    t.equal(aircraft.speed, 506.66359648192605)
+    t.equal(aircraft.heading, 65.76194226683805)
+    t.equal(aircraft.lat, 0)
+    t.equal(aircraft.lng, 0)
+    t.equal(aircraft.callsign, '')
+
+    t.end()
+  })
+})
+
+test('store timeout with system time', function (t) {
+  const store = new AircraftStore({timeout: 50})
+  const start = Date.now()
+
+  const options = {
+    refTime: null,
+    timeBetweenMessages: 0
+  }
+
+  populateStore(store, options, function () {
+    t.equal(store.getAircrafts().length, 1)
+    t.equal(store.getAircrafts(start + 51).length, 0)
+    t.end()
+  })
+})
+
+test('store timeout with reference time', function (t) {
   const store = new AircraftStore({timeout: 50})
 
-  populateStore(store, function () {
-    const aircrafts = store.getAircrafts()
-    t.equal(aircrafts.length, 1)
-    setTimeout(function () {
-      const aircrafts = store.getAircrafts()
-      t.equal(aircrafts.length, 0)
-      t.end()
-    }, 51)
+  const options = {
+    refTime: 4815162342,
+    timeBetweenMessages: 0
+  }
+
+  populateStore(store, options, function () {
+    t.equal(store.getAircrafts(options.refTime).length, 1)
+    t.equal(store.getAircrafts(options.refTime + 51).length, 0)
+    t.end()
   })
 })
 
-function populateStore (store, cb, _decoder, _index) {
-  if (!_decoder) _decoder = new Decoder()
-  if (!_index) _index = 0
-  if (msgs.length === _index) return cb()
-  setTimeout(function () {
-    store.addMessage(_decoder.parse(msgs[_index]))
-    populateStore(store, cb, _decoder, ++_index)
-  }, 1)
+function populateStore (store, options, cb) {
+  options.decoder = options.decoder || new Decoder()
+  options.refTime = options.refTime || Date.now()
+
+  for (let i = 0; i < msgs.length; i++) {
+    store.addMessage(
+      options.decoder.parse(msgs[i]),
+      options.refTime + options.timeBetweenMessages * i
+    )
+  }
+
+  return cb()
 }


### PR DESCRIPTION
`AircraftStore.addMessage()` and `AircraftStore.getAircrafts()` now accept an extra argument to set the reference time instead of the current system time.

This is useful if we need to add messages in a different order or process a stream of messages received in the past when we know the original times when the messages were received. It adds flexibility and simplifies some of the tests because we can avoid monkey-patching Date.now and waiting a few milliseconds with setTimeout.
